### PR TITLE
Added ignore for doc/tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+doc/tags


### PR DESCRIPTION
I keep my configs in a Git repository, and I use Vundle to manage my plugins.

Vundle (and Pathogen, I believe) automatically generates helptags (`doc/tags`) when this plugin is installed. Since this file is untracked, when I perform `git status` on my dotfiles repository, this shows up:

```
modified: .vim/bundle/vim-closer (untracked content)
```

This simply ignores `doc/tags` so the above doesn't show up when `git status` is called on an enclosing repository.
