### PR TITLE
Add support for Python

### DIFF
--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -10,7 +10,7 @@ augroup closer
     \ let b:closer_flags = '([{;' |
     \ let b:closer_no_semi = '^\s*\(function\|class\|if\|else\)' |
     \ let b:closer_semi_ctx = ')\s*{$'
-  au FileType c,cpp,css,go,java,less,objc,puppet,ruby,scss,sh,stylus,xdefaults,zsh
+  au FileType c,cpp,css,go,java,less,objc,puppet,python,ruby,scss,sh,stylus,xdefaults,zsh
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{'
 


### PR DESCRIPTION
Though Python does not use braces to delimit blocks, ([{ can still reasonably be closed:

```
# Make a tuple or parenthesize a value like a long string
x = (

# Make a list
y = [

# Make a dict
z = {
```
