### PR TITLE
add support for rust

### DIFF
--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -10,7 +10,7 @@ augroup closer
     \ let b:closer_flags = '([{;' |
     \ let b:closer_no_semi = '^\s*\(function\|class\|if\|else\)' |
     \ let b:closer_semi_ctx = ')\s*{$'
-  au FileType c,cpp,css,go,java,less,objc,puppet,python,ruby,scss,sh,stylus,xdefaults,zsh
+  au FileType c,cpp,css,go,java,less,objc,puppet,python,ruby,rust,scss,sh,stylus,xdefaults,zsh
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{'
 


### PR DESCRIPTION
Adds support for rust. Unfortunately, like C++, it has the complication of statements being terminated with a semicolon, but it works well enough for me and it's easy enough to just add semicolons manually when needed :)