### PR TITLE
PHP support

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -83,8 +83,10 @@ function! s:use_semicolon(ln)
   " Don't add semicolons for lines matching `no_semi`.
   " This allows `function(){ .. }` and `class X { .. }` to not get semicolons.
   let line = getline(a:ln)
-  let prevline = getline(a:ln - 1)
-  if b:closer_no_semi != '0' && (match(line, b:closer_no_semi) > -1 || match(prevline, b:closer_no_semi) > -1)
+  let topline = getline(a:ln - 1)
+  if b:closer_no_semi != '0' && match(line, b:closer_no_semi) > -1
+    return ''
+  elseif b:closer_no_semi != '0' && b:closer_semi_check_top != '0' && match(topline, b:closer_no_semi) > -1
     return ''
   endif
 

--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -83,7 +83,8 @@ function! s:use_semicolon(ln)
   " Don't add semicolons for lines matching `no_semi`.
   " This allows `function(){ .. }` and `class X { .. }` to not get semicolons.
   let line = getline(a:ln)
-  if b:closer_no_semi != '0' && match(line, b:closer_no_semi) > -1
+  let prevline = getline(a:ln - 1)
+  if b:closer_no_semi != '0' && (match(line, b:closer_no_semi) > -1 || match(prevline, b:closer_no_semi) > -1)
     return ''
   endif
 

--- a/doc/closer.txt
+++ b/doc/closer.txt
@@ -1,4 +1,5 @@
 *closer.txt*  automatically close brackets
+*vim-closer*
 
 ==============================================================================
 INTRODUCTION                                                            *closer*

--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -3,16 +3,25 @@ augroup closer
   autocmd FileType *
     \ let b:closer = 0 |
     \ let b:closer_no_semi = 0 |
-    \ let b:closer_semi_ctx = 0
+    \ let b:closer_semi_ctx = 0 |
+    \ let b:closer_semi_check_top = 0
 
   au FileType javascript,javascript.jsx,vue,typescript
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{;' |
     \ let b:closer_no_semi = '^\s*\(function\|class\|if\|else\)' |
     \ let b:closer_semi_ctx = ')\s*{$'
+
   au FileType c,cpp,css,go,java,less,objc,puppet,python,ruby,rust,scss,sh,stylus,xdefaults,zsh,terraform
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{'
+
+  au FileType php
+    \ let b:closer = 1 |
+    \ let b:closer_flags = '([{;' |
+    \ let b:closer_no_semi = '\s*\(function\|class\|if\|else\|for\|try\)' |
+    \ let b:closer_semi_ctx = '\s*{$' |
+    \ let b:closer_semi_check_top = 1
 
   autocmd FileType * call closer#enable()
 augroup END

--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -19,7 +19,7 @@ augroup closer
   au FileType php
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{;' |
-    \ let b:closer_no_semi = '\s*\(function\|class\|if\|else\|for\|try\)' |
+    \ let b:closer_no_semi = '\s*\(function\s\+.\+(\|class\|if\|else\|for\|try\)' |
     \ let b:closer_semi_ctx = '\s*{$' |
     \ let b:closer_semi_check_top = 1
 


### PR DESCRIPTION
mostly for php support and other c like languages with certain code style like:

```
public function test()
{
    |
}
```

```
public static function test()
{
    $result = $test->run(
        [
            |
        ]
    );
}
```

or

```
class Test
{
    |
}
```

Add new option for such situation `b:closer_semi_check_top` to also check two lines above the cursor position.