### PR TITLE
Add javacc support

### DIFF
--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -10,7 +10,7 @@ augroup closer
     \ let b:closer_flags = '([{;' |
     \ let b:closer_no_semi = '^\s*\(function\|class\|if\|else\)' |
     \ let b:closer_semi_ctx = ')\s*{$'
-  au FileType c,cpp,css,go,java,less,objc,puppet,python,ruby,rust,scss,sh,stylus,xdefaults,zsh,terraform
+  au FileType c,cpp,css,go,java,javacc,less,objc,puppet,python,ruby,rust,scss,sh,stylus,xdefaults,zsh,terraform
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{'
 


### PR DESCRIPTION
I found that `vim-closer` wasn't working when writing a parser with JavaCC. 
This pull request solves this issue.