### PR TITLE
Add javascriptreact and typescriptreact filetypes

### DIFF
--- a/plugin/closer.vim
+++ b/plugin/closer.vim
@@ -6,7 +6,7 @@ augroup closer
     \ let b:closer_semi_ctx = 0 |
     \ let b:closer_semi_check_top = 0
 
-  au FileType javascript,javascript.jsx,vue,typescript
+  au FileType javascript,javascript.jsx,javascriptreact,vue,typescript,typescriptreact
     \ let b:closer = 1 |
     \ let b:closer_flags = '([{;' |
     \ let b:closer_no_semi = '^\s*\(function\|class\|if\|else\)' |


### PR DESCRIPTION
See https://github.com/vim/vim/issues/4830 on the discussion for these new filetypes for ReactJS in JavaScript and TypeScript.

It's been added officially to Vim 8.1.1930: https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22
And neovim pulled in that support as well: https://github.com/neovim/neovim/commit/f667a0e02ac5781a7b7e640b5dc9a7edcf2f4a0b

Without this change, this awesome plugin does not seem to be working out of the box for `*.jsx` files.