### PR TITLE
Adds an option to not bind it to <CR>

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -15,12 +15,14 @@ function! closer#enable()
   let b:closer = 1
   let oldmap = maparg('<CR>', 'i')
 
-  if oldmap =~# 'CloserClose'
-    " already mapped. maybe the user was playing with `set ft`
-  elseif oldmap != ""
-    exe "imap <CR> ".oldmap."<Plug>CloserClose"
-  else
-    imap  <CR> <CR><Plug>CloserClose
+  if !exists('g:closer_no_mappings')
+	  if oldmap =~# 'CloserClose'
+		" already mapped. maybe the user was playing with `set ft`
+	  elseif oldmap != ""
+		exe "imap <CR> ".oldmap."<Plug>CloserClose"
+	  else
+		imap  <CR> <CR><Plug>CloserClose
+	  endif
   endif
 endfunction
 


### PR DESCRIPTION
Closes #33 and probably #30.

By setting `g:closer_no_mappings` to any value makes vim-closer not automatically bind to `<CR>`, so the user can have more control on how to bind it.

Example with nvim-compe and vim-endwise:

`g:closer_no_mappings` and `g:endwise_no_mappings` are set to 0
```lua
local opts = {expr = true, silent = true}
local mappings = {
	{"i", "<CR>", "v:lua.compeCR()", opts},
}

for _, map in pairs(mappings) do
	vim.api.nvim_set_keymap(unpack(map))
end

local t = function(str)
	return vim.api.nvim_replace_termcodes(str, true, true, true)
end

_G.compeCR = function()
	if vim.fn.pumvisible() == 1 and vim.fn.complete_info()['selected'] ~= -1 then
		vim.fn['compe#confirm']('<CR>')
	else
		return t "<CR><Plug>DiscretionaryEnd<Plug>CloserClose"
	end
end

``` 
