### PR TITLE
Fix mapping to play nicely with other plugins

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -13,17 +13,32 @@ endif
 function! closer#enable()
   if ! exists('b:closer_flags') | return | endif
   let b:closer = 1
-  let oldmap = maparg('<CR>', 'i')
+  let oldmap = maparg('<CR>', 'i', 0, 1)
+  let rhs = substitute(get(oldmap, 'rhs', ''), '\c<sid>', '<SNR>' . get(oldmap, 'sid') . '_', 'g')
 
-  if !exists('g:closer_no_mappings')
-	  if oldmap =~# 'CloserClose'
-		" already mapped. maybe the user was playing with `set ft`
-	  elseif oldmap != ""
-		exe "imap <CR> ".oldmap."<Plug>CloserClose"
-	  else
-		imap  <CR> <CR><Plug>CloserClose
-	  endif
+  if get(g:, 'closer_no_mappings') || rhs =~# 'CloserClose'
+    return
   endif
+
+  if get(oldmap, 'expr')
+    exe 'imap <script><silent><expr> <CR> closer#close(' . rhs . ')'
+  elseif rhs =~? '^<cr>' && rhs !~? '<plug>'
+    exe 'imap <silent><script> <CR>' rhs . '<SID>CloserClose'
+  elseif rhs =~? '^cr'
+    exe 'imap <silent> <CR>' rhs . '<SID>CloserClose'
+  elseif empty(rhs)
+    imap <script><silent><expr> <CR> closer#close("\r")
+  endif
+
+"   if !exists('g:closer_no_mappings')
+"     if get(oldmap, 'rhs') =~# 'CloserClose'
+"       return
+"     elseif oldmap != ""
+"       exe "imap <CR> ".oldmap."<Plug>CloserClose"
+"     else
+"       imap  <CR> <CR><Plug>CloserClose
+"     endif
+"   endif
 endfunction
 
 "
@@ -31,7 +46,12 @@ endfunction
 " Executed after pressing <CR>
 "
 
-function! closer#close()
+function! closer#close(...)
+  " tpope madness to play nicely with other plugins' <CR> mappings
+  if a:0 && type(a:1) == type('')
+    return a:1 . (a:1 =~# "\r" && empty(&buftype) ? "\<C-R>=closer#close()\r" : "")
+  endif
+
   if ! get(b:, 'closer') | return '' | endif
 
   " supress if it broke off a line (pressed enter not at the end)

--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -1,11 +1,17 @@
 if exists("g:closer_autoloaded") | finish | endif
 let g:closer_autoloaded=1
 
+if maparg("<Plug>CloserClose") == ""
+  inoremap <silent> <SID>CloserClose <C-R>=closer#close()<CR>
+  imap <script> <Plug>CloserClose <SID>CloserClose
+endif
+
 "
 " Enables closer for the current buffer.
 "
 
 function! closer#enable()
+  " Based on tpope's vim-eunuch <CR> mapping function
   if ! exists('b:closer_flags') | return | endif
   let b:closer = 1
   let oldmap = maparg('<CR>', 'i', 0, 1)
@@ -15,7 +21,6 @@ function! closer#enable()
     return
   endif
 
-  inoremap <silent> <SID>CloserClose <C-R>=closer#close()<CR>
   if get(oldmap, 'expr')
     exe 'imap <script><silent><expr> <CR> closer#close(' . rhs . ')'
   elseif rhs =~? '^<cr>' && rhs !~? '<plug>'

--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -1,11 +1,6 @@
 if exists("g:closer_autoloaded") | finish | endif
 let g:closer_autoloaded=1
 
-if maparg("<Plug>CloserClose") == ""
-  inoremap <silent> <SID>CloserClose <C-R>=closer#close()<CR>
-  imap <script> <Plug>CloserClose <SID>CloserClose
-endif
-
 "
 " Enables closer for the current buffer.
 "
@@ -20,6 +15,7 @@ function! closer#enable()
     return
   endif
 
+  inoremap <silent> <SID>CloserClose <C-R>=closer#close()<CR>
   if get(oldmap, 'expr')
     exe 'imap <script><silent><expr> <CR> closer#close(' . rhs . ')'
   elseif rhs =~? '^<cr>' && rhs !~? '<plug>'
@@ -29,16 +25,6 @@ function! closer#enable()
   elseif empty(rhs)
     imap <script><silent><expr> <CR> closer#close("\r")
   endif
-
-"   if !exists('g:closer_no_mappings')
-"     if get(oldmap, 'rhs') =~# 'CloserClose'
-"       return
-"     elseif oldmap != ""
-"       exe "imap <CR> ".oldmap."<Plug>CloserClose"
-"     else
-"       imap  <CR> <CR><Plug>CloserClose
-"     endif
-"   endif
 endfunction
 
 "


### PR DESCRIPTION
Fixes #37

Using tpope's suggestions, use an `<expr>` mapping if another plugin uses such a mapping.