### PR TITLE
Do not chain imaps on buffer switch

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -17,7 +17,7 @@ function! closer#enable()
   let oldmap = maparg('<CR>', 'i', 0, 1)
   let rhs = substitute(get(oldmap, 'rhs', ''), '\c<sid>', '<SNR>' . get(oldmap, 'sid') . '_', 'g')
 
-  if get(g:, 'closer_no_mappings') || rhs =~# 'CloserClose'
+  if get(g:, 'closer_no_mappings') || rhs =~# 'CloserClose' || rhs =~# 'closer#close'
     return
   endif
 


### PR DESCRIPTION
If `imap <cr>` is set by another plugin then every time there is a switch between buffers, the mapping is wrapped in another `closer#close` function call. This prevents that.