### PR TITLE
Fix bug in mapping

### DIFF
--- a/autoload/closer.vim
+++ b/autoload/closer.vim
@@ -17,7 +17,7 @@ function! closer#enable()
   let oldmap = maparg('<CR>', 'i', 0, 1)
   let rhs = substitute(get(oldmap, 'rhs', ''), '\c<sid>', '<SNR>' . get(oldmap, 'sid') . '_', 'g')
 
-  if get(g:, 'closer_no_mappings') || rhs =~# 'CloserClose'
+  if get(g:, 'closer_no_mappings') || rhs =~# '\MCloserClose\|closer#close'
     return
   endif
 


### PR DESCRIPTION
The regexp wouldn't catch when the `closer#close` function was directly mapped to, leading to chains of the mapping similar to this:

```
closer#close(closer#close(closer#close(closer#close(closer#close(...)))))
```

and the output of `<CR>` being very messy.